### PR TITLE
74 ao clicar na logo volta para o início da listagem de restaurantes

### DIFF
--- a/components/layouts/Navbar.tsx
+++ b/components/layouts/Navbar.tsx
@@ -36,12 +36,12 @@ const Navbar = ({ clearFilters = null }) => {
         <div className="hidden md:flex md:items-center md:justify-between md:gap-4">
           {/* Logo/Nome do site */}
           <Link
-            href="/"
+            href="/restaurants"
             className="flex items-center text-lg sm:text-xl font-bold text-amber-500 flex-shrink-0"
             onClick={(e) => {
-              if (clearFilters && (pathname === '/' || pathname === '/restaurants')) {
+              if (pathname === '/' || pathname === '/restaurants') {
                 e.preventDefault();
-                clearFilters();
+                window.scrollTo({ top: 0, behavior: 'smooth' });
               }
             }}
           >
@@ -91,12 +91,12 @@ const Navbar = ({ clearFilters = null }) => {
         {/* Versão mobile */}
         <div className="md:hidden flex items-center justify-between gap-2">
           <Link
-            href="/"
+            href="/restaurants"
             className="flex items-center text-lg font-bold text-amber-500 flex-shrink-0"
             onClick={(e) => {
-              if (clearFilters && (pathname === '/' || pathname === '/restaurants')) {
+              if (pathname === '/' || pathname === '/restaurants') {
                 e.preventDefault();
-                clearFilters();
+                window.scrollTo({ top: 0, behavior: 'smooth' });
               }
             }}
           >


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Logo now links to `/restaurants` instead of home page

- Click behavior scrolls to top smoothly instead of clearing filters

- Removed dependency on `clearFilters` prop for logo click handling

- Applied changes to both desktop and mobile navbar versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Logo Click"] --> B["Check Current Page"]
  B --> C["Home or Restaurants Page"]
  C --> D["Scroll to Top Smoothly"]
  B --> E["Other Pages"]
  E --> F["Navigate to /restaurants"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Navbar.tsx</strong><dd><code>Logo navigation and scroll behavior updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/layouts/Navbar.tsx

<ul><li>Changed logo <code>href</code> from "/" to "/restaurants" in desktop navbar<br> <li> Changed logo <code>href</code> from "/" to "/restaurants" in mobile navbar<br> <li> Replaced <code>clearFilters()</code> call with <code>window.scrollTo({ top: 0, behavior: </code><br><code>'smooth' })</code><br> <li> Removed <code>clearFilters</code> dependency check from onClick condition</ul>


</details>


  </td>
  <td><a href="https://github.com/BMSaiko/FoodLister/pull/80/files#diff-28e6a02b68c97408a719112aac2a5e6ecfbfa77e3eff48d2df14511110419608">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

